### PR TITLE
Kafka templates: document where the broker and credentials are configured

### DIFF
--- a/components/kafka/README.md
+++ b/components/kafka/README.md
@@ -36,6 +36,53 @@ against a real broker, not estimated.
 | **kafka-pull-service** | Long-running Service owns consumer + producer, batches, commits explicitly | at-least-once; your own DLQ routing | The workhorse: consume→transform→produce pipelines, aggregation windows, anything needing batching (`send-batch`), custom offset/commit policy, or a long-lived producer | You need exactly-once (see transactional) or truly trivial per-record work with no produce (handler is less code) |
 | **kafka-transactional** | Pull service + transactions: outputs and input offsets commit atomically | exactly-once (read-process-write) | Money, inventory, dedup-sensitive enrichment — anywhere a replayed or half-applied batch is unacceptable and downstream reads `read_committed` | Throughput matters more than duplicates (txn round trips cost); side effects leave Kafka (a DB write isn't covered by the transaction — then at-least-once + idempotent writes is the honest design) |
 
+## Where the broker and credentials are configured
+
+In the workload's own `cosmonic:kafka` entry under `hostInterfaces`, which is
+what every manifest here shows. That entry is the binding: `bootstrap.servers`,
+`security.protocol`, the SASL or TLS material, the topic grant, and the
+handler keys all live there, and the component never sees a broker address in
+its code.
+
+The plugin claims none of those keys deliberately. It owns the ones that would
+hand the *host process* a capability (see the rule below), and leaves the
+connection, the credential and the topics to the workload — which is what lets
+two workloads on one host reach different clusters as different principals.
+
+Secrets do not belong inline. `config` is for plain values, `configFrom` pulls
+a ConfigMap, and `secretFrom` pulls a Secret; the three merge in that order,
+so a password reaches librdkafka without appearing in the manifest:
+
+```yaml
+hostInterfaces:
+  - namespace: cosmonic
+    package: kafka
+    version: 0.3.0
+    interfaces: [producer, types]
+    config:
+      bootstrap.servers: my-kafka.kafka.svc.cluster.local:9092
+      security.protocol: SASL_SSL
+      sasl.mechanism: SCRAM-SHA-512
+      topics: "demo.events"
+    secretFrom:
+      - kafka-credentials      # sasl.username, sasl.password, ssl.ca.pem, ...
+```
+
+Whatever that entry sets wins over anything the component passes to
+`producer.open`/`consumer.open`, so a guest cannot redirect itself at another
+broker or substitute its own credential. A guest's own config is only consulted
+for keys the entry leaves unset.
+
+**An operator can take this over.** A host's plugin configuration accepts the
+same `config`/`configFrom`/`secretFrom`, plus named `bindings` a workload
+selects by label. Two settings decide how much a workload may still say:
+`hostOwnedKeys` claims additional keys for the host, and `workloadConfig`
+(`deny` by default) fails the deploy of a workload that sets a host-owned key
+or widens a grant declared for it. A platform team that owns the cluster puts
+the broker and credentials there once, and workloads name only the label and
+the topics they need. These templates take the self-contained route instead,
+so each runs on its own.
+
 ### Rules that apply to every pattern
 
 - **`handler.topics` and `topics` are different keys.** `handler.topics` is
@@ -44,9 +91,9 @@ against a real broker, not estimated.
   handler that reads one topic and writes another cannot express that with one
   key. Grant exactly what the workload touches; a pure handler needs no
   `topics` at all.
-- **The host pins whatever the manifest sets** (`bootstrap.servers`, creds,
-  the topic grant, `handler.group.id`, `transactional.id`) — guests cannot
-  override it. Put policy in the manifest, not the code.
+- **The binding entry beats the guest** (`bootstrap.servers`, creds, the topic
+  grant, `handler.group.id`, `transactional.id`) — a component cannot override
+  what the manifest sets. Put policy in the manifest, not the code.
 - **Some keys are the host's and are refused to a workload:** anything that
   loads native code (`plugin.library.paths`, `ssl.engine.location`,
   `ssl.providers`), reads a host file by path (the `ssl.*.location` keys,

--- a/components/kafka/rust/http-kafka-producer/README.md
+++ b/components/kafka/rust/http-kafka-producer/README.md
@@ -37,8 +37,14 @@ they are. Once you change the source, build it, push it to your own
 registry, and set that reference instead.
 
 The broker address and topic names in the manifests are placeholders. The
-kafka `hostInterfaces[].config` is **host-pinned**: whatever is set there
-(broker, topics grant, group.id, ...) wins over anything the component passes.
+workload's `cosmonic:kafka` entry under `hostInterfaces` is where the
+connection lives — broker, credentials, the topic grant — and whatever it sets
+wins over anything the component passes to `open`. Use `secretFrom` for the
+credential rather than inlining it.
+
+An operator can move all of this to the host's own plugin configuration
+instead, and a few keys are the host's either way. Both are covered in
+[the pattern guide](../../README.md#where-the-broker-and-credentials-are-configured).
 
 ## Tuning notes (measured, wasmCloud 2.8 / cosmonic:kafka 0.3.0)
 

--- a/components/kafka/rust/kafka-handler-consumer/README.md
+++ b/components/kafka/rust/kafka-handler-consumer/README.md
@@ -37,9 +37,12 @@ they are. Once you change the source, build it, push it to your own
 registry, and set that reference instead.
 
 The broker address and topic names in the manifests are placeholders. The
-kafka `hostInterfaces[].config` is **host-pinned**: whatever is set there
-(broker, credentials, the topic grant, `handler.group.id`) wins over anything
-the component passes to `open`.
+workload's `cosmonic:kafka` entry under `hostInterfaces` is where the
+connection lives — broker, credentials, the topic grant, `handler.group.id` —
+and whatever it sets wins over anything the component passes to `open`. Use
+`secretFrom` for the credential rather than inlining it. An operator can move
+all of this to the host's own plugin configuration instead; see
+[the pattern guide](../../README.md#where-the-broker-and-credentials-are-configured).
 
 Some keys are the host's, and a workload setting one is refused. They are the
 ones that would hand the host process a capability: loading native code

--- a/components/kafka/rust/kafka-pull-service/README.md
+++ b/components/kafka/rust/kafka-pull-service/README.md
@@ -37,8 +37,15 @@ they are. Once you change the source, build it, push it to your own
 registry, and set that reference instead.
 
 The broker address and topic names in the manifests are placeholders. The
-kafka `hostInterfaces[].config` is **host-pinned**: whatever is set there
-(broker, topics grant, group.id, ...) wins over anything the component passes.
+workload's `cosmonic:kafka` entry under `hostInterfaces` is where the
+connection lives — broker, credentials, the topic grant — and whatever it sets
+wins over anything the component passes to `open`, including the `group.id`
+this service opens its consumer with. Use `secretFrom` for the credential
+rather than inlining it.
+
+An operator can move all of this to the host's own plugin configuration
+instead, and a few keys are the host's either way. Both are covered in
+[the pattern guide](../../README.md#where-the-broker-and-credentials-are-configured).
 
 ## Tuning notes (measured, wasmCloud 2.8 / cosmonic:kafka 0.3.0)
 

--- a/components/kafka/rust/kafka-transactional/README.md
+++ b/components/kafka/rust/kafka-transactional/README.md
@@ -37,8 +37,15 @@ they are. Once you change the source, build it, push it to your own
 registry, and set that reference instead.
 
 The broker address and topic names in the manifests are placeholders. The
-kafka `hostInterfaces[].config` is **host-pinned**: whatever is set there
-(broker, topics grant, group.id, ...) wins over anything the component passes.
+workload's `cosmonic:kafka` entry under `hostInterfaces` is where the
+connection lives — broker, credentials, the topic grant, and the
+`transactional.id` that fences a restarted producer — and whatever it sets
+wins over anything the component passes to `open`. Use `secretFrom` for the
+credential rather than inlining it.
+
+An operator can move all of this to the host's own plugin configuration
+instead, and a few keys are the host's either way. Both are covered in
+[the pattern guide](../../README.md#where-the-broker-and-credentials-are-configured).
 
 ## Tuning notes (measured, wasmCloud 2.8 / cosmonic:kafka 0.3.0)
 


### PR DESCRIPTION
Stacked on #50, because the files it touches only exist after that move. GitHub retargets this to `main` once #50 merges.

## The question this answers

Where does an end user configure the connection to Kafka? The READMEs did not really say. They asserted the kafka config block was **host-pinned**, which reads two ways now that an operator can own the same keys — and the phrase was doing all the explaining.

The answer is the workload's own `cosmonic:kafka` entry under `hostInterfaces`. The plugin deliberately claims none of the connection, credential or topic keys; it owns only the ones that would hand the *host process* a capability. That is what lets two workloads on one host reach different clusters as different principals.

## What changed

The pattern guide gains a **Where the broker and credentials are configured** section covering:

- The workload entry, and that it beats anything the component passes to `open`, so a guest cannot redirect itself at another broker.
- `config` / `configFrom` / `secretFrom`, with a worked SASL_SSL example. Every example so far used a plaintext broker, so nothing showed the intended path for a password.
- The operator route, which nothing documented: a host's plugin configuration takes the same three, plus named `bindings` a workload selects by label, with `hostOwnedKeys` and `workloadConfig` (`deny` by default) deciding how much a workload may still say. A platform team owning the cluster puts the broker there once and workloads name only the label and their topics.

The four template READMEs now point at that section rather than repeating the ambiguous sentence, and each says what is specific to it — the pull service's `group.id`, the transactional template's `transactional.id`.

No code or manifests change.